### PR TITLE
Cedar-22 support

### DIFF
--- a/.profile.d/z_inject_react_app_env.sh
+++ b/.profile.d/z_inject_react_app_env.sh
@@ -29,7 +29,7 @@ set -e
 
 for js_bundle_filename in $js_bundle_filenames
 do
-  echo "Injecting runtime env into $js_bundle_filename (from .profile.d/inject_react_app_env.sh)"
+  echo "Injecting runtime env into $js_bundle_filename (from .profile.d/z_inject_react_app_env.sh)"
 
   # Render runtime env vars into bundle.
   ruby -E utf-8:utf-8 \

--- a/.profile.d/z_inject_react_app_env.sh
+++ b/.profile.d/z_inject_react_app_env.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+# Note: System ruby no longer installed in Cedar-22 onwards,
+# In order to be executed after Ruby buildpack,
+# this file's name has to be later than "ruby.sh"
+# in alphabetical order.
+# https://devcenter.heroku.com/articles/heroku-22-stack#system-ruby-is-no-longer-installed
+
 # Debug, echo every command
 #set -x
 

--- a/bin/compile
+++ b/bin/compile
@@ -38,7 +38,7 @@ cp "$BP_DIR/lib/injectable_env.rb" "$cra_dir/"
 
 profile_d_dir="$BUILD_DIR/.profile.d"
 mkdir -p "$profile_d_dir"
-cp "$BP_DIR/.profile.d/inject_react_app_env.sh" "$profile_d_dir/"
+cp "$BP_DIR/.profile.d/z_inject_react_app_env.sh" "$profile_d_dir/"
 
 # echo "       Installing brotli gem"
 # gem install --no-document --vendor -V brotli


### PR DESCRIPTION
:green_circle: Tested the buildpack on Heroku with `Cedar-20` and this can be safely merged

System ruby no longer installed in Cedar-22 onwards,
In order to be executed after Ruby buildpack, the file's name has to be later than "ruby.sh" in alphabetical order.
https://devcenter.heroku.com/articles/heroku-22-stack#system-ruby-is-no-longer-installed
